### PR TITLE
gradle関係での微修正

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,4 +83,7 @@ jar {
     }
 }
 
-tasks.withType(Jar) {compileJava.options.encoding = 'UTF-8'}
+tasks.withType(Jar) {
+    compileJava.options.encoding = 'UTF-8'
+    compileJava.options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+}

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -15,7 +15,7 @@ set DIRNAME=%~dp0
 if "%DIRNAME%" == "" set DIRNAME=.
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
-set JAVA_HOME=C:\PROGRA~1\Java\jdk1.8.0_91
+set JAVA_HOME=%JAVA_HOME%
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome


### PR DESCRIPTION
- gradlew.batにおいて、JDKのバージョンが固定されていたため、環境変数のJAVA_HOMEを利用するように変更しました。
- build.gradleにおいて、javacの引数を追加し、一部の警告の詳細を表示するようにしました。